### PR TITLE
Add a workflow for publishing to the prod repository

### DIFF
--- a/.github/workflows/chart-publish-preprod.yml
+++ b/.github/workflows/chart-publish-preprod.yml
@@ -1,20 +1,18 @@
-name: Production chart publish
+name: Preprod chart publish
 
-on:
-  push:
-    tags:
-      - "v*"
+on: [push]
 
 concurrency:
-  group: ${{ github.ref }}-chart-publish-prod
+  group: ${{ github.ref }}-chart-publish-preprod
 
 jobs:
   registry:
-    name: Publish the Helm chart to the Helm repository
+    name: Publish the chart to the preprod Helm repository
     runs-on: ubuntu-latest
     env:
       HELM_VERSION: "3.7.1"
-      REGISTRY_URL: "https://downloads.spacelift.io/helm"
+      REGISTRY_URL: "https://downloads.spacelift.dev/helm"
+      CHART_VERSION_PREFIX: "0.0.1-preprod"
 
     steps:
       - name: Check out repository code
@@ -38,12 +36,8 @@ jobs:
 
       - name: Set chart version number
         run: |
-          if [[ $GITHUB_REF_NAME != v* ]]; then
-            echo "Tag does not look like a valid version: $GITHUB_REF_NAME"
-            exit 1
-          fi
-
-          echo "CHART_VERSION=${GITHUB_REF_NAME:1}" >> $GITHUB_ENV
+          timestamp=$(date +'%s')
+          echo "CHART_VERSION=${CHART_VERSION_PREFIX}.${timestamp}" >> $GITHUB_ENV
 
       - name: Lint chart
         run: helm lint .
@@ -56,27 +50,27 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.PREPROD_AWS_REGION }}
+          aws-access-key-id: ${{ secrets.PREPROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PREPROD_AWS_SECRET_ACCESS_KEY }}
 
-      - name: Test uploading the provider data to S3
+      - name: Test uploading the chart to S3
         run: >-
           aws s3 sync
-          build/chart s3://${{ secrets.AWS_S3_BUCKET }}/helm
+          build/chart s3://${{ secrets.PREPROD_AWS_S3_BUCKET }}/helm
           --no-progress
           --dryrun
 
-      - name: Upload the provider data to S3
-        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+      - name: Upload the chart to S3
+        if: github.ref == 'refs/heads/main'
         run: >-
           aws s3 sync
-          build/chart s3://${{ secrets.AWS_S3_BUCKET }}/helm
+          build/chart s3://${{ secrets.PREPROD_AWS_S3_BUCKET }}/helm
           --no-progress
 
       - name: Invalidate cache
-        if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+        if: github.ref == 'refs/heads/main'
         run: >-
           aws cloudfront create-invalidation
-          --distribution-id ${{ secrets.DISTRIBUTION }}
+          --distribution-id ${{ secrets.PREPROD_DISTRIBUTION }}
           --paths "/helm/*"

--- a/.github/workflows/chart-publish-prod.yml
+++ b/.github/workflows/chart-publish-prod.yml
@@ -1,18 +1,20 @@
-name: Preprod registry
+name: Production chart publish
 
-on: [push]
+on:
+  push:
+    tags:
+      - "v*"
 
 concurrency:
-  group: ${{ github.ref }}-registry-preprod
+  group: ${{ github.ref }}-chart-publish-prod
 
 jobs:
   registry:
-    name: Publish the Helm chart to the registry
+    name: Publish the Helm chart to the Helm repository
     runs-on: ubuntu-latest
     env:
       HELM_VERSION: "3.7.1"
-      REGISTRY_URL: "https://downloads.spacelift.dev/helm"
-      CHART_VERSION_PREFIX: "0.0.1-preprod"
+      REGISTRY_URL: "https://downloads.spacelift.io/helm"
 
     steps:
       - name: Check out repository code
@@ -36,8 +38,12 @@ jobs:
 
       - name: Set chart version number
         run: |
-          timestamp=$(date +'%s')
-          echo "CHART_VERSION=${CHART_VERSION_PREFIX}.${timestamp}" >> $GITHUB_ENV
+          if [[ $GITHUB_REF_NAME != v* ]]; then
+            echo "Tag does not look like a valid version: $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          echo "CHART_VERSION=${GITHUB_REF_NAME:1}" >> $GITHUB_ENV
 
       - name: Lint chart
         run: helm lint .
@@ -50,27 +56,28 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ secrets.PREPROD_AWS_REGION }}
-          aws-access-key-id: ${{ secrets.PREPROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PREPROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Test uploading the provider data to S3
+      - name: Test uploading the chart to S3
         run: >-
           aws s3 sync
-          build/chart s3://${{ secrets.PREPROD_AWS_S3_BUCKET }}/helm
+          build/chart s3://${{ secrets.AWS_S3_BUCKET }}/helm
           --no-progress
           --dryrun
 
-      - name: Upload the provider data to S3
-        if: github.ref == 'refs/heads/main'
-        run: >-
-          aws s3 sync
-          build/chart s3://${{ secrets.PREPROD_AWS_S3_BUCKET }}/helm
-          --no-progress
+      # Uncomment after testing
+      # - name: Upload the chart to S3
+      #   if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+      #   run: >-
+      #     aws s3 sync
+      #     build/chart s3://${{ secrets.AWS_S3_BUCKET }}/helm
+      #     --no-progress
 
-      - name: Invalidate cache
-        if: github.ref == 'refs/heads/main'
-        run: >-
-          aws cloudfront create-invalidation
-          --distribution-id ${{ secrets.PREPROD_DISTRIBUTION }}
-          --paths "/helm/*"
+      # - name: Invalidate cache
+      #   if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+      #   run: >-
+      #     aws cloudfront create-invalidation
+      #     --distribution-id ${{ secrets.DISTRIBUTION }}
+      #     --paths "/helm/*"


### PR DESCRIPTION
- Added a new workflow to publish to downloads.spacelift.io. The process should work like this:
  - Make changes to `main` until we're ready to release.
  - Create a new release, creating a tag named `v<version>` (e.g. `v1.0.2`).
  - Creating the tag will trigger the workflow, which will package the chart and publish it.
- I renamed the workflows to avoid confusion with Helm terminology. It uses both terms `repository` and `registry`, and registries are a separate feature that isn't GA yet to use OCI-compatible registries to host Helm charts.
- For now I've commented out the steps that actually push to the downloads bucket. I want to test the simulation looks good when I create a release first.