### PR TITLE
Add lifecycle and support for extra volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ storageVolumeClaimTemplateSpec:
       storage: 100Gi
 ```
 
+### Extra volumes
+
+It is possible to add additional volumes to the Deployment or Stateful set by defining the `volumes`
+value and attach it to launcher container with `launcher.extraVolumeMounts`. This can for instance be
+useful to mount credentials for docker login if necessary.
+
+Example mounting a secret `config.json` to `/opt/docker`:
+
+```yaml
+launcher:
+  extraVolumeMounts:
+  - name: secret-volume
+    mountPath: /opt/docker/config.json
+    subPath: config.json
+
+volumes:
+- name: secret-volume
+  secret:
+    secretName: very-secret
+```
+
 ## Development
 
 ### Publishing the Chart

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -35,6 +35,13 @@ spec:
           imagePullPolicy: {{ .Values.launcher.image.pullPolicy }}
           resources:
             {{- toYaml .Values.launcher.resources | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - sleep 20
           env:
             - name: DOCKER_HOST
               value: tcp://localhost:2375
@@ -73,6 +80,16 @@ spec:
           # By default the Docker container starts the daemon with TLS enabled, which causes
           # the launcher to fail to connect to it. Specifying the command manually disables this.
           command: ["dockerd", "--host", "tcp://127.0.0.1:2375"]
+          env:
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - while [ ! -z $(docker ps -q) ]; do echo test; done;
           securityContext:
             privileged: true
           volumeMounts:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
+            {{- with .Values.launcher.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: dind
           image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
           imagePullPolicy: {{ .Values.dind.image.pullPolicy }}
@@ -104,10 +107,16 @@ spec:
         - name: launcher-storage
           emptyDir: {}
       {{- end }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.storageVolume }}
       volumes:
         - name: launcher-storage
           {{- toYaml . | nindent 10 }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -102,22 +102,17 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
-      {{- if not .Values.storageVolume }}
       volumes:
         - name: launcher-storage
+      {{- if not .Values.storageVolume }}
           emptyDir: {}
       {{- end }}
-        {{- with .Values.volumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
       {{- with .Values.storageVolume }}
-      volumes:
-        - name: launcher-storage
           {{- toYaml . | nindent 10 }}
+      {{- end }}
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
                 command:
                 - /bin/sh
                 - -c
-                - while [ ! -z $(docker ps -q) ]; do echo test; done;
+                - while [ ! -z $(docker ps -q) ]; do sleep 1; done;
           securityContext:
             privileged: true
           volumeMounts:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -36,6 +36,13 @@ spec:
           imagePullPolicy: {{ .Values.launcher.image.pullPolicy }}
           resources:
             {{- toYaml .Values.launcher.resources | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - sleep 20
           env:
             - name: DOCKER_HOST
               value: tcp://localhost:2375
@@ -66,6 +73,9 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
+            {{- with .Values.launcher.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: dind
           image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
           imagePullPolicy: {{ .Values.dind.image.pullPolicy }}
@@ -74,6 +84,16 @@ spec:
           # By default the Docker container starts the daemon with TLS enabled, which causes
           # the launcher to fail to connect to it. Specifying the command manually disables this.
           command: ["dockerd", "--host", "tcp://127.0.0.1:2375"]
+          env:
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - while [ ! -z $(docker ps -q) ]; do sleep 1; done;
           securityContext:
             privileged: true
           volumeMounts:
@@ -83,16 +103,17 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
-      {{- if not (or .Values.storageVolume .Values.storageVolumeClaimTemplateSpec) }}
       volumes:
         - name: launcher-storage
+      {{- if not (or .Values.storageVolume .Values.storageVolumeClaimTemplateSpec) }}
           emptyDir: {}
       {{- end }}
       {{- with .Values.storageVolume }}
-      volumes:
-        - name: launcher-storage
           {{- toYaml . | nindent 10 }}
       {{- end }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,7 @@ launcher:
   securityContext: {}
   # extraEnv allows you to inject additional environment variables to the launcher container.
   extraEnv: []
+  # extraVolumeMounts adds extra volume mounts to the launcher container.
   extraVolumeMounts: []
 
 # dind contains settings for the dind container.
@@ -62,6 +63,7 @@ tolerations: []
 
 affinity: {}
 
+# volumes specified extra volumes to attach to Deployment / StatefulSet.
 volumes: []
 
 # storageVolume specifies the template to use for the storage volume attached to the launcher (default `emptyDir`).

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,7 @@ launcher:
   securityContext: {}
   # extraEnv allows you to inject additional environment variables to the launcher container.
   extraEnv: []
+  extraVolumeMounts: []
 
 # dind contains settings for the dind container.
 dind:
@@ -60,6 +61,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+volumes: []
 
 # storageVolume specifies the template to use for the storage volume attached to the launcher (default `emptyDir`).
 storageVolume: {}


### PR DESCRIPTION
Adding lifecycle.preStop to not terminate the containers too early. For dind container it wait till there are no running docker containers. Wasn't sure if it was safe to terminate the launcher container before a job is finished.. so added a sleep to wait a little bit.
This prevents kubernetes from terminating the container while there is a running job.

Also added support for extra volume and volumeMount. Needed for mounting docker credentials.