### PR TITLE
Keep the replicas item for deployment and stateful sets as optional

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.replicas.enabled }}
+  {{- if .Values.replicasEnabled  }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.replicas.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "spacelift-worker.selectorLabels" . | nindent 6 }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- if .Values.replicas.enabled }}
+  {{- if .Values.replicasEnabled  }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -9,7 +9,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.replicas.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "spacelift-worker.selectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,6 @@
+# replicas.enabled is for, if you are using HPA, replicas can't be used. That line needs to be removed in order for the HPA to work.
+replicas:
+  enabled: true
 # replicaCount defines the number of Spacelift workers that will be created.
 replicaCount: 1
 # terminationGracePeriodSeconds specifies how long Kubernetes gives a worker pod to gracefully

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# replicas.enabled is for, if you are using HPA, replicas can't be used. That line needs to be removed in order for the HPA to work.
+# replicas.enabled defines whether the `replicas` field is set against the Deployment or StatefulSet. This allows you to prevent the field from being set when using a HPA, as recommended in the Kubernetes documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling.
 replicas:
   enabled: true
 # replicaCount defines the number of Spacelift workers that will be created.

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,5 @@
 # replicas.enabled defines whether the `replicas` field is set against the Deployment or StatefulSet. This allows you to prevent the field from being set when using a HPA, as recommended in the Kubernetes documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling.
-replicas:
-  enabled: true
+replicasEnabled : true
 # replicaCount defines the number of Spacelift workers that will be created.
 replicaCount: 1
 # terminationGracePeriodSeconds specifies how long Kubernetes gives a worker pod to gracefully


### PR DESCRIPTION
If the HPA is being used, replicas (in Deployment or StatefulSet) can't be used. 

That line needs to be removed in order for the HPA to work.