### PR TITLE
Bump deprecated GH Action

### DIFF
--- a/.github/workflows/chart-publish-preprod.yml
+++ b/.github/workflows/chart-publish-preprod.yml
@@ -54,7 +54,7 @@ jobs:
           helm repo index build/chart --url "$REGISTRY_URL" --merge "build/index-current.yaml"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.PREPROD_AWS_REGION }}
           role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/chart-publish-prod.yml
+++ b/.github/workflows/chart-publish-prod.yml
@@ -57,7 +57,7 @@ jobs:
           helm repo index build/chart --url "$REGISTRY_URL" --merge "build/index-current.yaml"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/