### PR TITLE
docker-init: handle linux init responsibilities

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -90,7 +90,12 @@ spec:
             {{- toYaml .Values.dind.resources | nindent 12 }}
           # By default the Docker container starts the daemon with TLS enabled, which causes
           # the launcher to fail to connect to it. Specifying the command manually disables this.
-          command: ["dockerd", "--host", "tcp://127.0.0.1:2375"]
+          command:
+            - docker-init
+            - "--"
+            - dockerd
+            - "--host"
+            - tcp://127.0.0.1:2375
           env:
             - name: DOCKER_HOST
               value: tcp://localhost:2375


### PR DESCRIPTION
`dockerd` doesn't handle PID1 responsibilities well.

Upstream issue:
https://github.com/docker-library/docker/issues/318

Blog description:
https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/


Given that we aren't on the latest version of `dind`, and we don't use the native entry point wrapper, we should add this logic to ensure that process reaping occurs as expected.

Local testing:
https://gist.github.com/lexton/f7684b70ce7ca2f090490ded9ff1b9ad
