### PR TITLE
Added support for `extraVolumeMounts` in the dind container

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -126,6 +126,9 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
+            {{- with .Values.dind.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: launcher-storage
       {{- if not .Values.storageVolume }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -122,6 +122,9 @@ spec:
             - name: launcher-storage
               mountPath: /opt/spacelift
               subPath: spacelift
+            {{- with .Values.dind.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: launcher-storage
       {{- if not (or .Values.storageVolume .Values.storageVolumeClaimTemplateSpec) }}

--- a/values.yaml
+++ b/values.yaml
@@ -66,6 +66,8 @@ dind:
   resources: {}
   # extraEnv allows you to inject additional environment variables to the dind container.
   extraEnv: []
+  # extraVolumeMounts adds extra volume mounts to the dind container.
+  extraVolumeMounts: []
 
 nodeSelector: {}
 


### PR DESCRIPTION
Same concept as in #17, fixed with #18 

Right now, there's no way to add additional `volumeMounts` to the `dind` container. 

A case in which this is useful is when a terraform configuration depends on modules stored in git rather than Spacelift. If additional SSL certs are required to connect to the git server, those could potentially be mounted in the worker/runner container with `SPACELIFT_WORKER_EXTRA_MOUNTS`, but while it's possible to define the environment variable there's no way to have the cert bundle mounted in the worker/runner if the bundle is not mounted in the host (`dind`) first