### PR TITLE
Use `--devel` flag for helm pull test for preprod

### DIFF
--- a/.github/workflows/chart-publish-preprod.yml
+++ b/.github/workflows/chart-publish-preprod.yml
@@ -105,5 +105,5 @@ jobs:
         run: |
           helm repo add spacelift https://downloads.spacelift.dev/helm
           helm repo update
-          helm pull spacelift/spacelift-worker
-          helm pull spacelift/vcs-agent          
+          helm pull --devel spacelift/spacelift-worker
+          helm pull --devel spacelift/vcs-agent


### PR DESCRIPTION
We use a pre-release version number for the preprod builds, which prevents `helm pull` from finding them by default.