### PR TITLE
Use --relative flag on production chart push

### DIFF
--- a/.github/workflows/chart-publish-preprod.yml
+++ b/.github/workflows/chart-publish-preprod.yml
@@ -85,14 +85,8 @@ jobs:
     needs: [registry]
     env:
       HELM_VERSION: "3.7.1"
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@master
-
       - name: Install Helm
         run: |
           curl -s https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm-v${HELM_VERSION}-linux-amd64.tar.gz

--- a/.github/workflows/chart-publish-prod.yml
+++ b/.github/workflows/chart-publish-prod.yml
@@ -69,15 +69,37 @@ jobs:
       - name: Package Spacelift Worker Pool chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/worker-pool spacelift-worker-pool/
-          helm s3 push build/chart/worker-pool/spacelift-worker-${CHART_VERSION}.tgz spacelift
+          helm s3 push --relative build/chart/worker-pool/spacelift-worker-${CHART_VERSION}.tgz spacelift
 
       - name: Package Spacelift VCS Agent chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/vcs-agent vcs-agent/
-          helm s3 push build/chart/vcs-agent/vcs-agent-${CHART_VERSION}.tgz spacelift
+          helm s3 push --relative build/chart/vcs-agent/vcs-agent-${CHART_VERSION}.tgz spacelift
 
       - name: Invalidate cache
         run: >-
           aws cloudfront create-invalidation
           --distribution-id ${{ secrets.DISTRIBUTION }}
           --paths "/helm/*"
+          
+  test-new-version:
+    name: Test that the new chart version can be pulled
+    runs-on: ubuntu-latest
+    needs: [registry]
+    env:
+      HELM_VERSION: "3.7.1"
+    steps:
+      - name: Install Helm
+        run: |
+          curl -s https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm-v${HELM_VERSION}-linux-amd64.tar.gz
+          tar -zxf helm-v${HELM_VERSION}-linux-amd64.tar.gz
+          sudo mv linux-amd64/helm /usr/local/bin
+          rm helm-v${HELM_VERSION}-linux-amd64.tar.gz
+          rm -rf linux-amd64
+
+      - name: Pull chart
+        run: |
+          helm repo add spacelift https://downloads.spacelift.io/helm
+          helm repo update
+          helm pull spacelift/spacelift-worker
+          helm pull spacelift/vcs-agent


### PR DESCRIPTION
- Using the `--relative` flag to ensure that the chart URLs don't include the `s3://` protocol. This allows them to be downloaded via the https URL (https://downloads.spacelift.io/helm).
- Added a test to make sure that both charts can be pulled after publishing a new version.