### PR TITLE
docs: update link to self-hosted docs

### DIFF
--- a/spacelift-self-hosted/README.md
+++ b/spacelift-self-hosted/README.md
@@ -4,5 +4,5 @@ This chart allows to deploy an instance of Spacelift in a self-hosted environmen
 
 ## Quick Start
 
-Depending on your environment, you can check the [guides here](https://user-documentation-shv3.onrender.com/self-hosted/latest/installing-spacelift/reference-architecture/guides.html) 
+Depending on your environment, you can check the [guides here](https:/docs.spacelift.io/self-hosted/latest/installing-spacelift/reference-architecture/guides) 
 for more details about how to use this chart.


### PR DESCRIPTION
Now that the docs changes for the reference architecture are live we can update this.

**NOTE:** we should not merge this change until we've released v3 of the self-hosted docs.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
