### PR TITLE
chore(CU-8698wre71): deprecate operator chart

### DIFF
--- a/spacelift-operator/Chart.yaml
+++ b/spacelift-operator/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: spacelift-operator
 description: A Helm chart for deploying the spacelift operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
+deprecated: true


### PR DESCRIPTION
See https://helm.sh/docs/topics/charts/#deprecating-charts

I'll remove the chart from the repo once the deprecated version will be published.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated

