### PR TITLE
chore: bump workerpool-controller version to v0.0.25

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: 0.7.0
-appVersion: "v0.0.23"
+version: 0.8.0
+appVersion: "v0.0.25"
 
 dependencies:
   - name: spacelift-promex


### PR DESCRIPTION
Bumps kube-workerpool-controller to v0.0.25 which includes the new pod cleanup logic per workerpool.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
