### PR TITLE
chore(workerpool-controller): bump promex chart to 0.59.0

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.13.0  # VERSION
+version: v0.14.0  # VERSION
 appVersion: "v0.0.28"
 
 dependencies:
   - name: crds
-    version: v0.13.0  # VERSION
+    version: v0.14.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
-    version: 0.47.0
+    version: 0.59.0
     repository: "https://downloads.spacelift.io/helm"
     condition: spacelift-promex.enabled

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.13.0
+CHART_VERSION ?= v0.14.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.13.0  # VERSION
+version: v0.14.0  # VERSION


### PR DESCRIPTION
Update workerpool-controller's promex dependency chart to version 0.59.0

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
