### PR TITLE
chore: bump k8s workerpool controller image to v0.0.32

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.14.0  # VERSION
-appVersion: "v0.0.28"
+version: v0.15.0  # VERSION
+appVersion: "v0.0.32"
 
 dependencies:
   - name: crds
-    version: v0.14.0  # VERSION
+    version: v0.15.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.59.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.14.0
+CHART_VERSION ?= v0.15.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.14.0  # VERSION
+version: v0.15.0  # VERSION

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -20,7 +20,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.28
+      tag: v0.0.32
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
Update k8s workerpool controller image to v0.0.32 and bump the chart to v0.15.0

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
