### PR TITLE
fix: grant secret read to k8s controller in namespaced mode

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.15.0  # VERSION
+version: v0.16.0  # VERSION
 appVersion: "v0.0.32"
 
 dependencies:
   - name: crds
-    version: v0.15.0  # VERSION
+    version: v0.16.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.59.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.15.0
+CHART_VERSION ?= v0.16.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.15.0  # VERSION
+version: v0.16.0  # VERSION

--- a/spacelift-workerpool-controller/templates/manager-rbac.yaml
+++ b/spacelift-workerpool-controller/templates/manager-rbac.yaml
@@ -93,7 +93,7 @@ metadata:
   labels:
   {{- include "spacelift-workerpool-controller.labels" $ | nindent 4 }}
 rules:
-{{ include "rules" . -}}
+{{ include "rules" $ -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -111,4 +111,37 @@ subjects:
     name: {{ include "spacelift-workerpool-controller.serviceAccountName" $ }}
     namespace: '{{ $.Release.Namespace }}'
 {{ end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "spacelift-workerpool-controller.fullname" . }}-manager-release-secrets-role
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "spacelift-workerpool-controller.fullname" . }}-manager-release-secrets-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "spacelift-workerpool-controller.fullname" . }}-manager-release-secrets-role'
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
+    namespace: '{{ .Release.Namespace }}'
 {{ end }}


### PR DESCRIPTION
Add Role and RoleBinding for reading secrets in .Release.Namespace when deployed in namespaced mode.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
