### PR TITLE
feat: add extraManifests support to the spacelift-self-hosted chart

### DIFF
--- a/spacelift-self-hosted/templates/extra-manifests.yaml
+++ b/spacelift-self-hosted/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -503,6 +503,14 @@
       "type": "string",
       "default": "spacelift",
       "description": "Override the full name used for resources"
+    },
+    "extraManifests": {
+      "type": "array",
+      "description": "List of additional Kubernetes manifests to render. Each item is rendered through the Helm template engine.",
+      "default": [],
+      "items": {
+        "type": "object"
+      }
     }
   },
   "$defs": {

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -191,5 +191,9 @@ ingressV6:
     # https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
+# Additional Kubernetes manifests to render with the chart. Items are rendered through
+# the template engine, so Helm template functions and values references are supported.
+extraManifests: []
+
 nameOverride: ""
 fullnameOverride: "spacelift"


### PR DESCRIPTION
Added `extraManifests` option to the `spacelift-self-hosted` chart so users can inject arbitrary Kubernetes manifests. To be used to include deployment-specific manifests such as network policies without having to use a separate chart.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
