### PR TITLE
feat: add terminationGracePeriodSeconds parameter to spacelift-self-hosted chart

### DIFF
--- a/spacelift-self-hosted/templates/drain-deployment.yaml
+++ b/spacelift-self-hosted/templates/drain-deployment.yaml
@@ -24,6 +24,9 @@ spec:
       serviceAccountName: {{ include "spacelift.drainServiceAccountName" . }}
       securityContext:
         {{- toYaml .Values.drain.podSecurityContext | nindent 8 }}
+      {{- if .Values.drain.terminationGracePeriodSeconds | empty | not }}
+      terminationGracePeriodSeconds: {{ .Values.drain.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.cloudSqlProxy.enabled }}
       initContainers:
         - name: cloud-sql-proxy

--- a/spacelift-self-hosted/templates/scheduler-deployment.yaml
+++ b/spacelift-self-hosted/templates/scheduler-deployment.yaml
@@ -24,6 +24,9 @@ spec:
       serviceAccountName: {{ include "spacelift.schedulerServiceAccountName" . }}
       securityContext:
         {{- toYaml .Values.scheduler.podSecurityContext | nindent 8 }}
+      {{- if .Values.scheduler.terminationGracePeriodSeconds | empty | not }}
+      terminationGracePeriodSeconds: {{ .Values.scheduler.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.cloudSqlProxy.enabled }}
       initContainers:
         - name: cloud-sql-proxy

--- a/spacelift-self-hosted/templates/server-deployment.yaml
+++ b/spacelift-self-hosted/templates/server-deployment.yaml
@@ -37,6 +37,9 @@ spec:
       serviceAccountName: {{ include "spacelift.serverServiceAccountName" . }}
       securityContext:
         {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      {{- if .Values.server.terminationGracePeriodSeconds | empty | not }}
+      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.cloudSqlProxy.enabled }}
       initContainers:
         - name: cloud-sql-proxy

--- a/spacelift-self-hosted/templates/vcs-gateway-deployment.yaml
+++ b/spacelift-self-hosted/templates/vcs-gateway-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       serviceAccountName: {{ include "spacelift.vcsGatewayServiceAccountName" . }}
       securityContext:
         {{- toYaml .Values.vcsGateway.podSecurityContext | nindent 8 }}
+      {{- if .Values.vcsGateway.terminationGracePeriodSeconds | empty | not }}
+      terminationGracePeriodSeconds: {{ .Values.vcsGateway.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.cloudSqlProxy.enabled }}
       initContainers:
         - name: cloud-sql-proxy

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -101,6 +101,10 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "description": "Duration in seconds that Kubernetes waits for the pod to terminate gracefully"
         }
       }
     },
@@ -162,6 +166,10 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "description": "Duration in seconds that Kubernetes waits for the pod to terminate gracefully"
         }
       }
     },
@@ -216,6 +224,10 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "description": "Duration in seconds that Kubernetes waits for the pod to terminate gracefully"
         }
       }
     },
@@ -290,6 +302,10 @@
         },
         "lifecycle": {
           "$ref": "#/$defs/lifecycle"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "description": "Duration in seconds that Kubernetes waits for the pod to terminate gracefully"
         },
         "service": {
           "type": "object",


### PR DESCRIPTION
To be used in combination with `PreStop` hook to implement graceful termination. This will be used to properly deregister the pods from AWS load balancers as it takes a few seconds for the AWS LBC to remove the Pod's IP from the target group and also to allow in-flight requests to complete (while the target is in the draining phase).