### PR TITLE
fix: CODEOWNERS fallback

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
+# Default owners for all files (fallback unless a later rule matches)
+# Platform team handles infrastructure and tooling, making them suitable for general chart maintenance.
+* @spacelift-io/platform
+
 # Ecosystem Team - External integrations and VCS connectivity
 /vcs-agent/ @spacelift-io/ecosystem-backend
 
@@ -14,7 +18,3 @@
 
 # Platform Team - Infrastructure, monitoring, and observability
 /spacelift-promex/ @spacelift-io/platform
-
-# Default owners for all files (fallback)
-# Platform team handles infrastructure and tooling, making them suitable for general chart maintenance.
-* @spacelift-io/platform


### PR DESCRIPTION
The CODEOWNERS file doesn't work quite how we intended because it actually gives precedence to later rules rather than earlier rules (i.e. it doesn't stop as soon as it finds a match, it uses the last match).

Here's the docs on it: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

Here's an example PR where Platform were assigned as reviewers instead of Enterprise Ready: https://github.com/spacelift-io/spacelift-helm-charts/pull/140.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
