### PR TITLE
feat(k8s-workerpool-controller): update to controller version v0.0.35

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.16.0  # VERSION
-appVersion: "v0.0.33"
+version: v0.17.0  # VERSION
+appVersion: "v0.0.35"
 
 dependencies:
   - name: crds
-    version: v0.16.0  # VERSION
+    version: v0.17.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.59.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.16.0
+CHART_VERSION ?= v0.17.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions
@@ -21,6 +21,9 @@ define generate_crd
 		| awk ' \
 			/^  annotations:/ { \
 				print; \
+				print "    {{- if .Values.keepOnUninstall }}"; \
+				print "    helm.sh/resource-policy: keep"; \
+				print "    {{- end }}"; \
 				print "    {{- with .Values.annotations }}"; \
 				print "    {{- toYaml . | nindent 4 }}"; \
 				print "    {{- end }}"; \

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.16.0  # VERSION
+version: v0.17.0  # VERSION

--- a/spacelift-workerpool-controller/charts/crds/templates/worker-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/worker-crd.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.keepOnUninstall }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- if .Values.keepOnUninstall }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -5736,6 +5739,12 @@ spec:
                       When set, this image will be used instead of the backend-provided runner image
                       for Ansible stacks.
                       Default: public.ecr.aws/spacelift/runner-ansible:latest
+                    type: string
+                  defaultIntentImage:
+                    description: |-
+                      DefaultIntentImage overrides the image used for the intent-worker container when
+                      running intent tasks. When set, this image is used instead of the backend-provided
+                      image for every intent task on this pool.
                     type: string
                   defaultRunnerImage:
                     description: |-
@@ -11521,32 +11530,29 @@ spec:
                   SpaceliftAPICredentials references a secret containing API credentials. This takes
                   precedence over the controller level credentials
                 properties:
-                  secretKeyRef:
-                    description: SecretKeySelector selects a key of a Secret.
-                    properties:
-                      key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
-                        type: string
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                      optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
-                        type: boolean
-                    required:
-                    - key
-                    type: object
-                    x-kubernetes-map-type: atomic
+                  keyEndpointField:
+                    default: endpoint
+                    description: KeyEndpointField is the key within the Secret that
+                      holds the Spacelift API endpoint.
+                    type: string
+                  keyIdField:
+                    default: keyId
+                    description: KeyIDField is the key within the Secret that holds
+                      the Spacelift API key ID.
+                    type: string
+                  keySecretField:
+                    default: keySecret
+                    description: KeySecretField is the key within the Secret that
+                      holds the Spacelift API key secret.
+                    type: string
+                  secretName:
+                    description: |-
+                      SecretName is the name of the Secret, in the WorkerPool's namespace, containing
+                      the Spacelift API credentials.
+                    minLength: 1
+                    type: string
                 required:
-                - secretKeyRef
+                - secretName
                 type: object
               successfulPodsHistoryLimit:
                 description: |-

--- a/spacelift-workerpool-controller/charts/crds/values.yaml
+++ b/spacelift-workerpool-controller/charts/crds/values.yaml
@@ -1,1 +1,2 @@
+keepOnUninstall: true
 annotations: {}

--- a/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
+++ b/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
@@ -5734,6 +5734,12 @@ spec:
                       for Ansible stacks.
                       Default: public.ecr.aws/spacelift/runner-ansible:latest
                     type: string
+                  defaultIntentImage:
+                    description: |-
+                      DefaultIntentImage overrides the image used for the intent-worker container when
+                      running intent tasks. When set, this image is used instead of the backend-provided
+                      image for every intent task on this pool.
+                    type: string
                   defaultRunnerImage:
                     description: |-
                       DefaultRunnerImage overrides the default runner image for non-Ansible runs.
@@ -11518,32 +11524,29 @@ spec:
                   SpaceliftAPICredentials references a secret containing API credentials. This takes
                   precedence over the controller level credentials
                 properties:
-                  secretKeyRef:
-                    description: SecretKeySelector selects a key of a Secret.
-                    properties:
-                      key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
-                        type: string
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                      optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
-                        type: boolean
-                    required:
-                    - key
-                    type: object
-                    x-kubernetes-map-type: atomic
+                  keyEndpointField:
+                    default: endpoint
+                    description: KeyEndpointField is the key within the Secret that
+                      holds the Spacelift API endpoint.
+                    type: string
+                  keyIdField:
+                    default: keyId
+                    description: KeyIDField is the key within the Secret that holds
+                      the Spacelift API key ID.
+                    type: string
+                  keySecretField:
+                    default: keySecret
+                    description: KeySecretField is the key within the Secret that
+                      holds the Spacelift API key secret.
+                    type: string
+                  secretName:
+                    description: |-
+                      SecretName is the name of the Secret, in the WorkerPool's namespace, containing
+                      the Spacelift API credentials.
+                    minLength: 1
+                    type: string
                 required:
-                - secretKeyRef
+                - secretName
                 type: object
               successfulPodsHistoryLimit:
                 description: |-

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -1,5 +1,9 @@
 crds:
   install: true
+  # When true, CRDs are annotated with helm.sh/resource-policy: keep so that
+  # `helm uninstall` does not delete them (and cascade-delete every WorkerPool
+  # and Worker custom resource users have created).
+  keepOnUninstall: true
   annotations: {}
 
 controllerManager:
@@ -20,7 +24,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.33
+      tag: v0.0.35
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
Update Kubernetes Workerpool Controller image to version v0.0.35 which adds support for running Spacelift Intent tasks as well as setting Spacelift API credentials per Workerpool CR, and allows to override the Intent image used by the Workerpool.

Update the Kubernetes Workerpool Controller Helm chart to allow enabling/disabling of CRDs uinstall when the chart is being uninstalled.

- [x] A chart version is updated
  - [ ] No changes on CRDs
  - [x] CRDs are updated
