### PR TITLE
feat(vcs-agent): add existing secret support

### DIFF
--- a/vcs-agent/Chart.yaml
+++ b/vcs-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vcs-agent
 description: A Helm chart for deploying Spacelift VCS Agent
 type: application
-version: 0.2.0
+version: 0.3.0
 
 # The appVersion is the version of the VCS Agent binary. Since the chart is currently configured
 # to always use the latest version, this is set to "latest".

--- a/vcs-agent/README.md
+++ b/vcs-agent/README.md
@@ -32,8 +32,33 @@ To authenticate with Spacelift, you need to set the `SPACELIFT_VCS_AGENT_POOL_TO
 environment variables. By default, this chart will create a Kubernetes secret for you and configure both environment variables if you set the `credentials.token`, `credentials.endpoint` and `credentials.vendor`
 variables.
 
-If you want to provide your credentials another way, set `credentials.create` to `false`, and
-use the `vcs-agent.extraEnv` value to provide the variables yourself. For example:
+### Using an existing secret
+
+If you manage the credentials secret outside of the chart (for example with the
+[External Secrets Operator](https://external-secrets.io/)), set `credentials.existingSecret` to the
+name of that secret. The chart will not create or manage a secret of its own, and will source the
+environment variables from the secret you reference:
+
+```yaml
+credentials:
+  existingSecret: spacelift-vcs-agent
+```
+
+The secret is expected to contain the keys `token`, `endpoint` and `vendor`. If your secret uses
+different key names, override them:
+
+```yaml
+credentials:
+  existingSecret: spacelift-vcs-agent
+  tokenSecretKey: SPACELIFT_VCS_AGENT_POOL_TOKEN
+  endpointSecretKey: SPACELIFT_VCS_AGENT_TARGET_BASE_ENDPOINT
+  vendorSecretKey: SPACELIFT_VCS_AGENT_VENDOR
+```
+
+### Providing credentials another way
+
+Alternatively, set `credentials.create` to `false` and use the `vcs-agent.extraEnv` value to provide
+the variables yourself. For example:
 
 ```yaml
 credentials:

--- a/vcs-agent/templates/_helpers.tpl
+++ b/vcs-agent/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Name of the secret holding the VCS Agent credentials. Uses the externally-managed
+secret when set, otherwise the chart-managed secret.
+*/}}
+{{- define "vcs-agent.secretName" -}}
+{{- default (include "vcs-agent.fullname" .) .Values.credentials.existingSecret }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "vcs-agent.serviceAccountName" -}}

--- a/vcs-agent/templates/deployment.yaml
+++ b/vcs-agent/templates/deployment.yaml
@@ -39,22 +39,23 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if .Values.credentials.create }}
+            {{- if or .Values.credentials.create .Values.credentials.existingSecret }}
+            {{- $secretName := include "vcs-agent.secretName" . }}
             - name: SPACELIFT_VCS_AGENT_POOL_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "vcs-agent.fullname" . }}
-                  key: token
+                  name: {{ $secretName }}
+                  key: {{ .Values.credentials.tokenSecretKey }}
             - name: SPACELIFT_VCS_AGENT_TARGET_BASE_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "vcs-agent.fullname" . }}
-                  key: endpoint
+                  name: {{ $secretName }}
+                  key: {{ .Values.credentials.endpointSecretKey }}
             - name: SPACELIFT_VCS_AGENT_VENDOR
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "vcs-agent.fullname" . }}
-                  key: vendor
+                  name: {{ $secretName }}
+                  key: {{ .Values.credentials.vendorSecretKey }}
             {{- end }}
             {{- with .Values.vcsagent.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/vcs-agent/templates/secret.yaml
+++ b/vcs-agent/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.credentials.create }}
+{{- if and .Values.credentials.create (not .Values.credentials.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "vcs-agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  token: {{ .Values.credentials.token | quote }}
-  endpoint: {{ .Values.credentials.endpoint | quote }}
-  vendor: {{ .Values.credentials.vendor | quote }}
+  {{ .Values.credentials.tokenSecretKey }}: {{ .Values.credentials.token | quote }}
+  {{ .Values.credentials.endpointSecretKey }}: {{ .Values.credentials.endpoint | quote }}
+  {{ .Values.credentials.vendorSecretKey }}: {{ .Values.credentials.vendor | quote }}
 {{- end }}

--- a/vcs-agent/values.yaml
+++ b/vcs-agent/values.yaml
@@ -3,9 +3,11 @@ replicaCount: 1
 # revisionHistoryLimit: 3
 
 credentials:
-  # create defines whether a secret should be created for the VCS Agent credentials. If you want to pass
-  # the credentials in via a different method, set this to false and use the `vcs-agent.extraEnv`
-  # value to set the `SPACELIFT_VCS_AGENT_POOL_TOKEN`, `SPACELIFT_VCS_AGENT_TARGET_BASE_ENDPOINT` and `SPACELIFT_VCS_AGENT_VENDOR` environment variables.
+  # create defines whether a secret should be created for the VCS Agent credentials from the token,
+  # endpoint and vendor values below. To use a secret you manage outside of the chart (for example one
+  # created by the External Secrets Operator), set `existingSecret` instead. If you want to pass the
+  # credentials in some other way, set this to false and use the `vcs-agent.extraEnv` value to set the
+  # `SPACELIFT_VCS_AGENT_POOL_TOKEN`, `SPACELIFT_VCS_AGENT_TARGET_BASE_ENDPOINT` and `SPACELIFT_VCS_AGENT_VENDOR` environment variables.
   create: true
   # token contains the token downloaded from Spacelift when creating your VCS Agent pool.
   token: ""
@@ -13,6 +15,16 @@ credentials:
   endpoint: ""
   # vendor contains the VCS vendor to use.
   vendor: ""
+  # existingSecret is the name of an existing secret holding the VCS Agent credentials, managed outside
+  # of the chart (for example by the External Secrets Operator). When set, the chart does not create its
+  # own secret and the token, endpoint and vendor values above are ignored.
+  existingSecret: ""
+  # tokenSecretKey, endpointSecretKey and vendorSecretKey are the keys within `existingSecret` that hold
+  # each value. They default to the keys used by the chart-managed secret, so an existing secret with
+  # matching keys only needs `existingSecret` to be set.
+  tokenSecretKey: token
+  endpointSecretKey: endpoint
+  vendorSecretKey: vendor
 
 image:
   repository: public.ecr.aws/spacelift/vcs-agent


### PR DESCRIPTION
Source the VCS Agent credentials from a secret managed outside of the chart, for example one created by the External Secrets Operator. Set credentials.existingSecret to the name of that secret to reference it directly instead of creating one.

Give existingSecret precedence: skip the chart-managed secret when it is set, so pointing at an external secret needs no other change. Read the secret keys from tokenSecretKey, endpointSecretKey and vendorSecretKey, defaulting to the chart's own key names so a matching secret only needs existingSecret to be set.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
