### PR TITLE
feat(mqtt): add flag to conditionally include or exclude MQTT service

### DIFF
--- a/spacelift-self-hosted/templates/NOTES.txt
+++ b/spacelift-self-hosted/templates/NOTES.txt
@@ -4,7 +4,7 @@
   kubectl get ingresses --namespace "{{ .Release.Namespace }}"
 {{- end }}
 
-{{- if eq .Values.mqttService.type "LoadBalancer" }}
+{{- if and .Values.mqttService.enabled (eq .Values.mqttService.type "LoadBalancer") }}
 2. Get the MQTT service address by running this command:
 
   kubectl get services --namespace "{{ .Release.Namespace }}" "{{ include "spacelift.fullname" . }}-mqtt"

--- a/spacelift-self-hosted/templates/mqtt-service.yaml
+++ b/spacelift-self-hosted/templates/mqtt-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mqttService.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
       name: server
   selector:
     {{- include "spacelift.serverSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -471,6 +471,11 @@
       "description": "MQTT service configuration",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the MQTT service"
+        },
         "type": {
           "$ref": "#/$defs/serviceType",
           "default": "ClusterIP"

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -182,6 +182,7 @@ service:
   port: 80
 
 mqttService:
+  enabled: true
   type: ClusterIP
   port: 1984
   annotations: {}


### PR DESCRIPTION
MQTT service is not relevant when using IoT Core broker. Also, when converting from builtin broker, existence of the MQTT service might cause the pod's readiness gate to indicate unhealthy.