### PR TITLE
feat: add drain.schedulerEnabled toggle for embedded cron scheduler

### DIFF
--- a/spacelift-self-hosted/templates/drain-deployment.yaml
+++ b/spacelift-self-hosted/templates/drain-deployment.yaml
@@ -114,6 +114,10 @@ spec:
           env:
             - name: ENABLE_INSTRUMENTATION_ENDPOINTS
               value: "true"
+            {{- if .Values.drain.schedulerEnabled }}
+            - name: DRAIN_SCHEDULER_ENABLED
+              value: "true"
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.shared.secretRef }}

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -131,6 +131,11 @@
         "pullPolicy": {
           "$ref": "#/$defs/imagePullPolicy"
         },
+        "schedulerEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run the cron scheduler inside the drain pod instead of the standalone scheduler deployment"
+        },
         "securityContext": {
           "$ref": "#/$defs/securityContext"
         },

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -43,6 +43,8 @@ drain:
   replicaCount: 3
   secretRef:
   pullPolicy: Always
+  # Run the cron scheduler inside the drain pod. Leave false if you run the standalone scheduler deployment.
+  schedulerEnabled: false
   securityContext:
   # TODO Make sure we can run the image as non root user
   #  runAsNonRoot: true


### PR DESCRIPTION
Adds an optional toggle to run the cron scheduler inside the drain pod.

- New `drain.schedulerEnabled` value, default `false`.
- When `true`, the drain sets `DRAIN_SCHEDULER_ENABLED` and runs the cron scheduler itself.
- When `false`, nothing changes and the standalone scheduler keeps running the cronjobs.
- The env var is only rendered when the toggle is on, so it never overrides a value set through the drain secret.

Part of folding the scheduler into the drain. Backend PR: https://github.com/spacelift-io/backend/pull/14922
