### PR TITLE
feat: enable HPA scaling of drain

### DIFF
--- a/spacelift-self-hosted/templates/drain-deployment.yaml
+++ b/spacelift-self-hosted/templates/drain-deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "spacelift.drainLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.drain.replicaCount }}
+  {{- with .Values.drain.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "spacelift.drainSelectorLabels" . | nindent 6 }}

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -117,9 +117,12 @@
       "additionalProperties": false,
       "properties": {
         "replicaCount": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "default": 3,
-          "description": "Number of drain replicas"
+          "description": "Number of drain replicas. Might be set to 'null' to enable external components to scale drain"
         },
         "secretRef": {
           "type": [


### PR DESCRIPTION
Update self-hosted chart to allow _NOT_ setting drain replicas, thus allowing external actors (like HPA) to manage that field.

Note to self: add a screenshot of metadata.managedFields when this chart version is used

- [ ] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated

https://app.clickup.com/t/2384866/869byhm9n
