### PR TITLE
feat: bump kube-workerpool-controller to 0.0.40

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
 version: v0.18.0  # VERSION
-appVersion: "v0.0.38"
+appVersion: "v0.0.40"
 
 dependencies:
   - name: crds

--- a/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
@@ -1249,7 +1249,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -3526,7 +3525,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -3698,8 +3697,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -5624,7 +5622,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -6487,7 +6484,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -7085,7 +7081,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -8707,7 +8702,7 @@ spec:
                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            The volume will be mounted read-only (ro).
                             Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
@@ -8879,8 +8874,7 @@ spec:
                           description: |-
                             portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                             Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                            is on.
+                            are redirected to the pxd.portworx.com CSI driver.
                           properties:
                             fsType:
                               description: |-
@@ -10062,7 +10056,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -11170,7 +11163,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -11342,8 +11335,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-

--- a/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
+++ b/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
@@ -1243,7 +1243,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -3520,7 +3519,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -3692,8 +3691,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-
@@ -5618,7 +5616,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -6481,7 +6478,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -7079,7 +7075,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -8701,7 +8696,7 @@ spec:
                             A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            The volume will be mounted read-only (ro).
                             Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
@@ -8873,8 +8868,7 @@ spec:
                           description: |-
                             portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                             Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                            is on.
+                            are redirected to the pxd.portworx.com CSI driver.
                           properties:
                             fsType:
                               description: |-
@@ -10056,7 +10050,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -11164,7 +11157,7 @@ spec:
                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                          The volume will be mounted read-only (ro).
                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                         properties:
@@ -11336,8 +11329,7 @@ spec:
                         description: |-
                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                          is on.
+                          are redirected to the pxd.portworx.com CSI driver.
                         properties:
                           fsType:
                             description: |-

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -24,7 +24,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.38
+      tag: v0.0.40
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
Ships the label-length fix (workers no longer crash from over-long pod labels, https://github.com/spacelift-io/kube-workerpool-controller/pull/244) and reverts the temporary `tlsmlkem=0` FIPS workaround (https://github.com/spacelift-io/kube-workerpool-controller/pull/248), along with the usual dependency and Go toolchain bumps.