### PR TITLE
feat(promex): add support for priorityClassName

### DIFF
--- a/spacelift-promex/templates/deployment.yaml
+++ b/spacelift-promex/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: spacelift-promex
           {{- if .Values.image.digest }}

--- a/spacelift-promex/values.yaml
+++ b/spacelift-promex/values.yaml
@@ -21,6 +21,9 @@ annotations:
 # podAnnotations:
 #   app.spacelift.io/example: spacelift-promx
 
+# Priority class name for the pod
+priorityClassName: ""
+
 ## Your api endpoint, must be provided
 #apiEndpoint: https://{myaccount}.app.spacelift.io
 #


### PR DESCRIPTION
### Description
This PR adds support for `priorityClassName` to the `spacelift-promex` chart. 

Since the PromEx exporter is a critical infrastructure component for autoscaling, users often need to assign it a higher priority class (e.g., to prevent eviction or scheduling delays during cluster contention).

### Changes
- Added `priorityClassName` to `spacelift-promex/values.yaml`
- Injected `priorityClassName` into the Deployment pod spec in `spacelift-promex/templates/deployment.yaml`