### PR TITLE
chore: bump the promex chart version for the worker pool controller chart

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.18.0  # VERSION
+version: v0.18.0 # VERSION
 appVersion: "v0.0.40"
 
 dependencies:
   - name: crds
-    version: v0.18.0  # VERSION
+    version: v0.18.0 # VERSION
     condition: crds.install
   - name: spacelift-promex
-    version: 0.59.0
+    version: 0.73.0
     repository: "https://downloads.spacelift.io/helm"
     condition: spacelift-promex.enabled


### PR DESCRIPTION
A new version of the Prometheus exporter chart has been released so I'm updating the worker pool controller chart to use the latest version.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
