### PR TITLE
feat(workerpool-controller): add controller PDB

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.18.0 # VERSION
+version: v0.19.0  # VERSION
 appVersion: "v0.0.40"
 
 dependencies:
   - name: crds
-    version: v0.18.0 # VERSION
+    version: v0.19.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.73.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.18.0
+CHART_VERSION ?= v0.19.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions

--- a/spacelift-workerpool-controller/README.md
+++ b/spacelift-workerpool-controller/README.md
@@ -22,6 +22,11 @@ Follow the instructions on the [user-documentation](https://docs.spacelift.io/co
 
 ## Rolling Upgrades and Pod Disruption Budgets
 
+Two separate PDBs are available: `pdb` protects the **worker** pods that execute runs, and
+`controllerManager.pdb` protects the **controller** pods themselves. Both are disabled by default.
+
+### Worker pods
+
 When performing rolling Kubernetes upgrades (e.g., EKS node AMI updates), you can protect in-flight
 runs from disruption by enabling the Pod Disruption Budget (PDB):
 
@@ -35,7 +40,7 @@ This creates a PDB that targets all worker pods managed by the controller. With 
 `kubectl drain` will not evict any worker pod that is currently executing a run. The drain will proceed
 once runs complete and pods terminate naturally.
 
-### Configuration Options
+#### Configuration Options
 
 | Value | Description | Default |
 |-------|-------------|---------|
@@ -46,20 +51,41 @@ once runs complete and pods terminate naturally.
 Exactly one of `minAvailable` or `maxUnavailable` must be set when `pdb.enabled: true`. Setting
 both, or neither, fails the install/upgrade with a template error.
 
-### Namespace Considerations
+#### Namespace Considerations
 
 The PDB is namespace-scoped. When `controllerManager.namespaces` is configured, a PDB is created in
 each specified namespace. Otherwise, the PDB is created in the release namespace. If you run in
 cluster-wide mode and have WorkerPools in multiple namespaces, you may need to create additional PDBs
 manually in those namespaces.
 
-### Notes
+#### Notes
 
 - The PDB targets worker pods using the `workers.spacelift.io/workerpool` label, which is
   automatically applied to all worker pods by the controller.
 - A PDB with no matching pods (e.g., when no runs are active) is a no-op and will not block drains.
 - The PDB only affects voluntary disruptions (e.g., `kubectl drain`). It does not affect direct pod
   deletions or involuntary disruptions like node crashes.
+
+### Controller pods
+
+The controller runs active/passive under leader election: whatever the replica count, exactly one pod
+holds the lease and does the work.
+
+```yaml
+controllerManager:
+  replicas: 2
+  pdb:
+    enabled: true
+```
+
+| Value | Description | Default |
+|-------|-------------|---------|
+| `controllerManager.pdb.enabled` | Enable PDB for controller pods | `false` |
+| `controllerManager.pdb.maxUnavailable` | Maximum unavailable controller pods | `1` |
+| `controllerManager.pdb.minAvailable` | Minimum available controller pods | - |
+
+The controller PDB is always created in the release namespace, alongside the Deployment, regardless
+of `controllerManager.namespaces`.
 
 ## Maintaining CRDs and chart versions
 

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.18.0  # VERSION
+version: v0.19.0  # VERSION

--- a/spacelift-workerpool-controller/templates/controller-pdb.yaml
+++ b/spacelift-workerpool-controller/templates/controller-pdb.yaml
@@ -1,0 +1,21 @@
+{{- $pdb := .Values.controllerManager.pdb }}
+{{- if $pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager-pdb
+  labels:
+    control-plane: controller-manager
+  {{- include "spacelift-workerpool-controller.labels" . | nindent 4 }}
+spec:
+  {{- with $pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with $pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "spacelift-workerpool-controller.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -109,7 +109,10 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ include "spacelift-workerpool-controller.serviceAccountName" . }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
+      {{- with .Values.controllerManager.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.controllerManager.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8}}

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -49,6 +49,29 @@ controllerManager:
   extraLabels: {}
   extraVolumes: []
   enforceFips140: false
+
+  # How long Kubernetes waits for the controller to shut down gracefully before
+  # killing it.
+  terminationGracePeriodSeconds: 30
+
+  # Priority class for the controller pods, e.g. system-cluster-critical.
+  priorityClassName: ""
+
+  # Pod Disruption Budget for the controller-manager pods. Only meaningful with
+  # replicas > 1 — the controller runs active/passive under leader election, so a
+  # single replica has nothing to fall back to.
+  pdb:
+    enabled: false
+    # How many controller pods a voluntary disruption (node drain, rolling upgrade)
+    # may take down at once. Safe at any replica count, but with several replicas it
+    # forces one eviction at a time even though only one pod is ever active.
+    maxUnavailable: 1
+    # Alternative to maxUnavailable, expressed as a floor instead of a ceiling: how
+    # many controller pods must stay running. Since leader election keeps exactly one
+    # pod active, 1 is enough at any replica count, and it drains faster than
+    # maxUnavailable once you run more than two.
+    # minAvailable: 1
+
 kubernetesClusterDomain: cluster.local
 # The metric service will expose a metrics endpoint that can be scraped by a prometheus instance.
 # This is disabled by default, enable this if you want to enable controller observability.


### PR DESCRIPTION
Add controllerManager.pdb so the controller-manager Deployment can be protected from voluntary disruptions the same way worker pods already are. It defaults to maxUnavailable: 1, which is safe at any replica count, and accepts minAvailable for pools running more than two replicas.

Expose terminationGracePeriodSeconds and priorityClassName on the controller pod. The grace period was hardcoded to 10 seconds while the controller's own graceful shutdown timeout is 30, so the kubelet cut shutdown short; it now defaults to 30 and existing installs pick that up on upgrade.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
