### PR TITLE
feat(workerpool-controller): bump to v0.0.41

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.19.0  # VERSION
-appVersion: "v0.0.40"
+version: v0.20.0  # VERSION
+appVersion: "v0.0.41"
 
 dependencies:
   - name: crds
-    version: v0.19.0  # VERSION
+    version: v0.20.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.73.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.19.0
+CHART_VERSION ?= v0.20.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.19.0  # VERSION
+version: v0.20.0  # VERSION

--- a/spacelift-workerpool-controller/charts/crds/templates/worker-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/worker-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: workers.workers.spacelift.io
 spec:
   group: workers.spacelift.io

--- a/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: workerpools.workers.spacelift.io
 spec:
   group: workers.spacelift.io
@@ -6344,6 +6344,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.
@@ -6941,6 +7178,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.
@@ -7550,6 +8024,12 @@ spec:
                     description: ServiceAccountName is the name of the ServiceAccount
                       to use to run this pod.
                     type: string
+                  shareProcessNamespace:
+                    description: |-
+                      ShareProcessNamespace lets the containers in the pod see and signal each other's processes,
+                      which a sidecar can use to coordinate with the builtin containers during shutdown.
+                      Optional: Default to false.
+                    type: boolean
                   terminationGracePeriodSeconds:
                     description: |-
                       Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
@@ -9916,6 +10396,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.

--- a/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
+++ b/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: workerpools.workers.spacelift.io
 spec:
   group: workers.spacelift.io
@@ -6338,6 +6338,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.
@@ -6935,6 +7172,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.
@@ -7544,6 +8018,12 @@ spec:
                     description: ServiceAccountName is the name of the ServiceAccount
                       to use to run this pod.
                     type: string
+                  shareProcessNamespace:
+                    description: |-
+                      ShareProcessNamespace lets the containers in the pod see and signal each other's processes,
+                      which a sidecar can use to coordinate with the builtin containers during shutdown.
+                      Optional: Default to false.
+                    type: boolean
                   terminationGracePeriodSeconds:
                     description: |-
                       Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
@@ -9910,6 +10390,243 @@ spec:
                           Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
+                      lifecycle:
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          A preStop hook can be used to order shutdown between the containers of a worker pod, for
+                          example to hold the gRPC server open until the worker has reported its results.
+                          Kubernetes rejects lifecycle hooks on init containers, so this field is only usable on
+                          grpcServerContainer and workerContainer.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+                        properties:
+                          postStart:
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              sleep:
+                                description: Sleep represents a duration that the
+                                  container should sleep.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
+                                type: object
+                              tcpSocket:
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for backward compatibility. There is no validation of this field and
+                                  lifecycle hooks will fail at runtime when it is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
+                        type: object
                       resources:
                         description: |-
                           Compute Resources required by this container.

--- a/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workers.yaml
+++ b/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: workers.workers.spacelift.io
 spec:
   group: workers.spacelift.io

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -24,7 +24,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.40
+      tag: v0.0.41
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
Update the controller image to v0.0.41 and refresh the WorkerPool CRD.

WorkerPool gains lifecycle hooks on spec.pod.workerContainer and spec.pod.grpcServerContainer, so postStart and preStop commands can run in the pods created for runs. spec.pod .shareProcessNamespace is also new, letting the containers in one of those pods see each other's processes.

The Worker CRD schema is unchanged; only its controller-gen annotation moved.

- [x] A chart version is updated
  - [ ] No changes on CRDs
  - [x] CRDs are updated

Addresses https://github.com/spacelift-io/spacelift-helm-charts/issues/155